### PR TITLE
Add Google Analytics GA4 code (Issue #45)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,9 @@ disqus:
 # Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
 google_analytics: UA-43339302-11
 
+# For newer "GA4" analytics, use the following instead of the "UA" entry above
+#google_analytics_ga4: G-GABC1DEFG
+
 # Your website URL (e.g. http://amitmerchant1990.github.io or http://www.amitmerchant.com)
 # Used for Sitemap.xml and your RSS feed
 url: http://www.amitmerchant.com/reverie

--- a/_includes/analytics_head.html
+++ b/_includes/analytics_head.html
@@ -1,0 +1,9 @@
+{% if site.google_analytics_ga4 %}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_ga4 }}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{ site.google_analytics_ga4 }}');
+      </script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,7 @@
 
     <meta name="theme-color" content="#000000">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/images/favicon-32x32.png">
+    {% include analytics_head.html %}
   </head>
 
   <body>


### PR DESCRIPTION
Hi Amit,

Thanks for all your work on this great theme.

I noticed Issue #45 about new style "GA4" analytics and I had already fixed it in my generated version, so here is a PR for you to review.

There's different ways to tackle this - maybe auto-detect by looking at the form of the `google_analytics` id given ("G-..." or "UA-...").

In my version I just used 2 config values.  It also looks if GA4 is set and if so doesnt include the old UA stuff.  Someone might want it though I guess, so I didn't do that in this PR.

(To do it, my `analytics.html` line 1: `{% if site.google_analytics_ua and not site.google_analytics_ga4 %}`)

Note that as I'm starting fresh, in my site I also renamed the existing `google_analytics` to `google_analytics_ua` but that's very "breaky" for existing users!

Anyway, this PR as it is seems to me like a non-breaking easy implementation for the main repo.

YMMV, but my wish is that this at least saves you a little time in addressing the issue.

Thanks again for a great theme.

Paul