### PR TITLE
Adds an Archive Page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,7 @@
               <a href="{{ site.baseurl }}/getting-started">Getting Started</a>
               <a href="{{ site.baseurl }}/search">Search</a>
               <a href="{{ site.baseurl }}/about">About</a>
+              <a href="{{ site.baseurl }}/archive">Archive</a>
             </nav>
           </header>
         </div>

--- a/_pages/archive.md
+++ b/_pages/archive.md
@@ -1,0 +1,33 @@
+---
+layout: page
+permalink: /archive/
+title: Posts Archive
+---
+
+
+<div id="archives">
+  <section id="archive">
+     <h3>Most Recent Posts</h3>
+      {%for post in site.posts %}
+      {% unless post.next %}
+      <ul class="this">
+          {% else %}
+          {% capture month %}{{ post.date | date: '%B %Y' }}{% endcapture %}
+          {% capture nmonth %}{{ post.next.date | date: '%B %Y' }}{% endcapture %}
+          {% capture year %}{{ post.date | date: '%Y' }}{% endcapture %}
+          {% capture nyear %}{{ post.next.date | date: '%Y' }}{% endcapture %}
+          {% if year != nyear %}
+      </ul>
+      <h2 style="text-align:left;">{{ post.date | date: '%Y' }}</h2>
+      <ul class="past">
+          {% endif %}
+          {% if month != nmonth %}
+          <h3 style="text-align:left;">{{ post.date | date: '%B %Y' }}</h3>
+          {% endif %}
+          {% endunless %}
+          <p><b><a href="{{ site.baseurl }}{{ post.url }}">{% if post.title and post.title != "" %}{{post.title}}{% else %}{{post.excerpt |strip_html}}{%endif%}</a></b> - {% if post.date and post.date != "" %}{{ post.date | date: "%e %B %Y" }}{%endif%}</p>
+          {% endfor %}
+      </ul>
+    <h3>Oldest Posts</h3>
+  </section>
+</div>


### PR DESCRIPTION
Hi there,

I'd like to start by thanking you for this great work and has made my life so much much nicer since I moved to GitHub Pages from WordPress.

I made this archive page that shows all posts on the site by date (newest first) and separates them out by month (you can see an example on my site [here](https://blog.josh.me.uk/archive/)). This PR also adds a link to the archive to the navigation at the top of each page.

### Possible (probably necessary) Improvements

- If possible there should probably be an option to enable it in [the config file](_config.yml)
- I'd also like the month and year of the first post to be shown (to be the same as everything else) but for some reason, I couldn't get it working

My HTML knowledge is not up to solving these but I thought it would be worth sharing as it might be useful - even in its current form.

Kind Regards,

[Josh](https://josh.me.uk) 