### PR TITLE
Update config.yml to support only GA4

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Your Jekyll blog will often be viewable immediately at <https://yourgithubuserna
 
 Enter your site name, description, avatar and many other options by editing the `_config.yml` file. You can easily turn on Google Analytics tracking, Disqus commenting and social icons here.
 
+> Note : Support reference to migrate UA analytics tag to GA4 - https://blog.google/products/ads-commerce/upgrade-to-google-analytics-4-before-july-1/
+
 Making a change to `_config.yml` (or any file in your repository) will force GitHub Pages to rebuild your site with Jekyll. Your rebuilt site will be viewable a few seconds later at <https://yourgithubusername.github.io> - if not, give it ten minutes as GitHub suggests and it'll appear soon.
 
 ### 3. Publish your first blog post

--- a/_config.yml
+++ b/_config.yml
@@ -40,11 +40,9 @@ footer-links:
 # You can find your shortname on the Settings page of your Disqus account
 disqus: 
 
-# Enter your Google Analytics web tracking code (e.g. UA-2110908-2) to activate tracking
-google_analytics: UA-43339302-11
-
-# For newer "GA4" analytics, use the following instead of the "UA" entry above
-#google_analytics_ga4: G-GABC1DEFG
+# For newer "GA4" analytics, use the following instead of the previous "UA" tags
+# As of July 1, 2023, UA tags no longer functional, view readme for more.
+google_analytics_ga4: G-GABC1DEFG
 
 # Your website URL (e.g. http://amitmerchant1990.github.io or http://www.amitmerchant.com)
 # Used for Sitemap.xml and your RSS feed


### PR DESCRIPTION
- Removed older UA tag from config.
- Reference guide to Import old UA tags to newer GA4, added as a reference to readme of the project.